### PR TITLE
Prevents code from running early

### DIFF
--- a/autoPlay.js
+++ b/autoPlay.js
@@ -1,7 +1,7 @@
 // ==UserScript== 
 // @name Monster Minigame AutoScript
 // @author /u/mouseasw for creating and maintaining the script, /u/WinneonSword for the Greasemonkey support, and every contributor on the GitHub repo for constant enhancements. /u/wchill and contributors on his repo for MSG2015-specific improvements.
-// @version 1.91
+// @version 1.92
 // @namespace https://github.com/wchill/steamSummerMinigame
 // @description A script that runs the Steam Monster Minigame for you.
 // @match http://steamcommunity.com/minigame/towerattack*
@@ -57,6 +57,11 @@ var ENEMY_TYPE = {
 	"MINIBOSS":3,
 	"TREASURE":4
 };
+// Prevent script from running before the game has loaded.
+var startingInterval = window.setInterval(startRunOnFullLoad, 3000);
+function startRunOnFullLoad() { if (document.getElementById("upgr_0") != null) {window.clearInterval(startingInterval);
+																																							 autoPlayScript()}}
+function autoPlayScript() {
 
 // Save old functions for toggles.
 var trt_oldCrit = window.g_Minigame.CurrentScene().DoCritEffect;
@@ -619,10 +624,12 @@ if(enableAutoClicker) {
 	}
 }
 
-alert("Autoscript now enabled - your game ID is " + g_GameID +
+if(alertOnRun) {alert("Autoscript now enabled - your game ID is " + g_GameID +
 	"\nAutoclicker: " + (enableAutoClicker?"enabled - "+clickRate+"cps, "+(setClickVariable?"variable":"clicks"):"disabled") +
 	"\nParticle effects: " + (disableParticleEffects?"disabled":"enabled") +
 	"\nFlinching effect: " + (disableFlinching?"disabled":"enabled") +
 	"\nCrit effect: " + (disableCritText?"disabled":"enabled") +
 	"\nText: " + (disableText?"disabled":"enabled")
 	);
+}
+}


### PR DESCRIPTION
Added a safety to prevent the script from running while the game hasn't loaded properly yet, which could result in some minor issues.
Added a check for the alertOnRun variable, so that it actually disables the alert when set to false.
