### PR TITLE
Re-enabling Attack Abilities Fix

### DIFF
--- a/autoPlay.js
+++ b/autoPlay.js
@@ -273,6 +273,7 @@ function goToLaneWithBestTarget() {
 				// ignore if lane is empty
 				if(g_Minigame.CurrentScene().m_rgGameData.lanes[i].dps == 0)
 					continue;
+					rainingGold = false;
 				var stacks = 0;
 				if(typeof g_Minigame.m_CurrentScene.m_rgLaneData[i].abilities[17] != 'undefined')
 					stacks = g_Minigame.m_CurrentScene.m_rgLaneData[i].abilities[17];


### PR DESCRIPTION
Sometimes if the game was particularly fast-paced, the Attack Abilities and Items would never re-enable after being disabled for Raining Gold. This adds a second re-enable flag which fixes that.
