### PR TITLE
Add auto-refresh option (only for GM users)

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -27,7 +27,7 @@ var removeFlinching = getPreferenceBoolean("removeFlinching", true);
 var removeCritText = getPreferenceBoolean("removeCritText", false);
 var removeAllText = getPreferenceBoolean("removeAllText", false);
 
-if (GM_info !== "undefined") {
+if (typeof GM_info !== "undefined") {
 	var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", true); // auto-refresh for GM/TM users
 } else {
 	var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", false); // no auto-refresh for non-GM/TM users

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -30,7 +30,7 @@ var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", true); // auto
 
 var enableElementLock = getPreferenceBoolean("enableElementLock", true);
 
-var autoRefreshSeconds = 60; // refresh page after x seconds
+var autoRefreshSeconds = 120; // refresh page after x seconds
 
 // DO NOT MODIFY
 var isAlreadyRunning = false;
@@ -71,6 +71,8 @@ var ENEMY_TYPE = {
 	"MINIBOSS":3,
 	"TREASURE":4
 };
+
+var refreshTimer = null; // global to cancel running timers if disabled after timer has already started
 
 
 function firstRun() {
@@ -292,7 +294,7 @@ function toggleAutoRefresh(event) {
     if(value) {
         autoRefreshPage(autoRefreshSeconds);
     } else {
-		enableAutoRefresh = false;	
+		clearTimeout(refreshTimer);	
     }
 }
 
@@ -1094,12 +1096,7 @@ function getClickDamage(){
 }
 
 function autoRefreshPage(autoRefreshSeconds){
-	if(enableAutoRefresh) {
-		setTimeout("location.reload(true);",(autoRefreshSeconds*1000));
-	}
-	else {
-		console.log("auto-refresh has been disabled, so no refresh);
-	}
+	refreshTimer = setTimeout("location.reload(true);",(autoRefreshSeconds*1000));
 }
 
 function enhanceTooltips(){

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -174,7 +174,6 @@ function firstRun() {
 	checkboxes.appendChild(makeCheckBox("removeCritText", "Remove crit text", removeCritText, toggleCritText));
 	checkboxes.appendChild(makeCheckBox("removeAllText", "Remove all text (overrides above)", removeAllText, toggleAllText));
 	checkboxes.appendChild(makeCheckBox("enableElementLock", "Lock element upgrades", enableElementLock, toggleElementLock));
-	checkboxes.appendChild(makeCheckBox("enableElementLock", "Lock element upgrades", enableElementLock, toggleElementLock));
 	info_box.appendChild(checkboxes);
 	
 	enhanceTooltips();

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1101,7 +1101,7 @@ function getClickDamage(){
 }
 
 function autoRefreshPage(autoRefreshSeconds){
-	refreshTimer = setTimeout("location.reload(true);",(autoRefreshSeconds*1000));
+	refreshTimer = setTimeout(function(){w.location.reload(true);},autoRefreshSeconds*1000);
 }
 
 function enhanceTooltips(){

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -30,7 +30,7 @@ var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", true); // auto
 
 var enableElementLock = getPreferenceBoolean("enableElementLock", true);
 
-var autoRefreshSeconds = 120; // refresh page after x seconds
+var autoRefreshSeconds = 1800; // refresh page after x seconds
 
 // DO NOT MODIFY
 var isAlreadyRunning = false;

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -5,7 +5,7 @@
 // @version 3.7.0
 // @match *://steamcommunity.com/minigame/towerattack*
 // @match *://steamcommunity.com//minigame/towerattack*
-// @grant none 
+// @grant none
 // @updateURL https://raw.githubusercontent.com/wchill/steamSummerMinigame/master/autoPlay.user.js
 // @downloadURL https://raw.githubusercontent.com/wchill/steamSummerMinigame/master/autoPlay.user.js
 // ==/UserScript==

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -30,7 +30,7 @@ var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", typeof GM_info
 
 var enableElementLock = getPreferenceBoolean("enableElementLock", true);
 
-var autoRefreshSeconds = 1800; // refresh page after x seconds
+var autoRefreshMinutes = 30; // refresh page after x seconds
 
 // DO NOT MODIFY
 var isAlreadyRunning = false;
@@ -137,7 +137,7 @@ function firstRun() {
 	}
 
 	if (enableAutoRefresh) {
-		autoRefreshPage(autoRefreshSeconds);
+		autoRefreshPage(autoRefreshMinutes);
 	}
 
 	if (w.CSceneGame !== undefined) {
@@ -293,7 +293,7 @@ function toggleAutoRefresh(event) {
     if(event !== undefined)
         value = handleCheckBox(event);
     if(value) {
-        autoRefreshPage(autoRefreshSeconds);
+        autoRefreshPage(autoRefreshMinutes);
     } else {
 		clearTimeout(refreshTimer);	
     }
@@ -1096,8 +1096,8 @@ function getClickDamage(){
     return g_Minigame.m_CurrentScene.m_rgPlayerTechTree.damage_per_click;
 }
 
-function autoRefreshPage(autoRefreshSeconds){
-	refreshTimer = setTimeout(function(){w.location.reload(true);},autoRefreshSeconds*1000);
+function autoRefreshPage(autoRefreshMinutes){
+	refreshTimer = setTimeout(function(){w.location.reload(true);},autoRefreshMinutes*1000*60);
 }
 
 function enhanceTooltips(){

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -5,7 +5,7 @@
 // @version 3.7.0
 // @match *://steamcommunity.com/minigame/towerattack*
 // @match *://steamcommunity.com//minigame/towerattack*
-// @grant none
+// @grant none 
 // @updateURL https://raw.githubusercontent.com/wchill/steamSummerMinigame/master/autoPlay.user.js
 // @downloadURL https://raw.githubusercontent.com/wchill/steamSummerMinigame/master/autoPlay.user.js
 // ==/UserScript==
@@ -26,7 +26,7 @@ var removeParticles = getPreferenceBoolean("removeParticles", true);
 var removeFlinching = getPreferenceBoolean("removeFlinching", true);
 var removeCritText = getPreferenceBoolean("removeCritText", false);
 var removeAllText = getPreferenceBoolean("removeAllText", false);
-var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", true); // auto-refresh the page to clear out stale memory from leak
+var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", false); // auto-refresh the page to clear out stale memory from leak
 
 var enableElementLock = getPreferenceBoolean("enableElementLock", true);
 
@@ -167,7 +167,9 @@ function firstRun() {
 	checkboxes.style["column-count"] = 2;
 	
 	checkboxes.appendChild(makeCheckBox("enableAutoClicker", "Enable autoclicker", enableAutoClicker, toggleAutoClicker));
-	checkboxes.appendChild(makeCheckBox("enableAutoRefresh", "Enable auto-refresh (fix memory leak)", enableAutoRefresh, toggleAutoRefresh));
+	if (typeof GM_info !==  "undefined") {
+		checkboxes.appendChild(makeCheckBox("enableAutoRefresh", "Enable auto-refresh (fix memory leak)", enableAutoRefresh, toggleAutoRefresh));
+	};
 	checkboxes.appendChild(makeCheckBox("removeInterface", "Remove interface (needs refresh)", removeInterface, handleEvent));
 	checkboxes.appendChild(makeCheckBox("removeParticles", "Remove particle effects (needs refresh)", removeParticles, handleEvent));
 	checkboxes.appendChild(makeCheckBox("removeFlinching", "Remove flinching effects (needs refresh)", removeFlinching, handleEvent));

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -26,12 +26,8 @@ var removeParticles = getPreferenceBoolean("removeParticles", true);
 var removeFlinching = getPreferenceBoolean("removeFlinching", true);
 var removeCritText = getPreferenceBoolean("removeCritText", false);
 var removeAllText = getPreferenceBoolean("removeAllText", false);
+var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", typeof GM_info !== "undefined");
 
-if (typeof GM_info !== "undefined") {
-	var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", true); // auto-refresh for GM/TM users
-} else {
-	var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", false); // no auto-refresh for non-GM/TM users
-}
 var enableElementLock = getPreferenceBoolean("enableElementLock", true);
 
 var autoRefreshSeconds = 1800; // refresh page after x seconds

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -169,7 +169,7 @@ function firstRun() {
 	checkboxes.appendChild(makeCheckBox("enableAutoClicker", "Enable autoclicker", enableAutoClicker, toggleAutoClicker));
 	if (typeof GM_info !==  "undefined") {
 		checkboxes.appendChild(makeCheckBox("enableAutoRefresh", "Enable auto-refresh (fix memory leak)", enableAutoRefresh, toggleAutoRefresh));
-	};
+	}
 	checkboxes.appendChild(makeCheckBox("removeInterface", "Remove interface (needs refresh)", removeInterface, handleEvent));
 	checkboxes.appendChild(makeCheckBox("removeParticles", "Remove particle effects (needs refresh)", removeParticles, handleEvent));
 	checkboxes.appendChild(makeCheckBox("removeFlinching", "Remove flinching effects (needs refresh)", removeFlinching, handleEvent));

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -26,8 +26,11 @@ var removeParticles = getPreferenceBoolean("removeParticles", true);
 var removeFlinching = getPreferenceBoolean("removeFlinching", true);
 var removeCritText = getPreferenceBoolean("removeCritText", false);
 var removeAllText = getPreferenceBoolean("removeAllText", false);
+var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", true); // auto-refresh the page to clear out stale memory from leak
 
 var enableElementLock = getPreferenceBoolean("enableElementLock", true);
+
+var autoRefreshSeconds = 60; // refresh page after x seconds
 
 // DO NOT MODIFY
 var isAlreadyRunning = false;
@@ -131,6 +134,10 @@ function firstRun() {
 		document.body.style.backgroundPosition = "0 0";
 	}
 
+	if (enableAutoRefresh) {
+		autoRefreshPage(autoRefreshSeconds);
+	}
+
 	if (w.CSceneGame !== undefined) {
 		w.CSceneGame.prototype.DoScreenShake = function() {};
 	}
@@ -158,11 +165,13 @@ function firstRun() {
 	checkboxes.style["column-count"] = 2;
 	
 	checkboxes.appendChild(makeCheckBox("enableAutoClicker", "Enable autoclicker", enableAutoClicker, toggleAutoClicker));
+	checkboxes.appendChild(makeCheckBox("enableAutoRefresh", "Enable auto-refresh (fix memory leak)", enableAutoRefresh, toggleAutoRefresh));
 	checkboxes.appendChild(makeCheckBox("removeInterface", "Remove interface (needs refresh)", removeInterface, handleEvent));
 	checkboxes.appendChild(makeCheckBox("removeParticles", "Remove particle effects (needs refresh)", removeParticles, handleEvent));
 	checkboxes.appendChild(makeCheckBox("removeFlinching", "Remove flinching effects (needs refresh)", removeFlinching, handleEvent));
 	checkboxes.appendChild(makeCheckBox("removeCritText", "Remove crit text", removeCritText, toggleCritText));
 	checkboxes.appendChild(makeCheckBox("removeAllText", "Remove all text (overrides above)", removeAllText, toggleAllText));
+	checkboxes.appendChild(makeCheckBox("enableElementLock", "Lock element upgrades", enableElementLock, toggleElementLock));
 	checkboxes.appendChild(makeCheckBox("enableElementLock", "Lock element upgrades", enableElementLock, toggleElementLock));
 	info_box.appendChild(checkboxes);
 	
@@ -273,6 +282,17 @@ function toggleAutoClicker(event) {
         currentClickRate = clickRate;
     } else {
         currentClickRate = 0;
+    }
+}
+
+function toggleAutoRefresh(event) {
+    var value = enableAutoRefresh;
+    if(event !== undefined)
+        value = handleCheckBox(event);
+    if(value) {
+        autoRefreshPage(autoRefreshSeconds);
+    } else {
+		autoRefreshSeconds = 0;
     }
 }
 
@@ -1071,6 +1091,12 @@ function getDPS(){
 
 function getClickDamage(){
     return g_Minigame.m_CurrentScene.m_rgPlayerTechTree.damage_per_click;
+}
+
+function autoRefreshPage(autoRefreshSeconds){
+	if(autoRefreshSeconds > 0) {
+		setTimeout("location.reload(true);",(autoRefreshSeconds*1000));
+	}
 }
 
 function enhanceTooltips(){

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -30,7 +30,7 @@ var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", typeof GM_info
 
 var enableElementLock = getPreferenceBoolean("enableElementLock", true);
 
-var autoRefreshMinutes = 30; // refresh page after x seconds
+var autoRefreshMinutes = 30; // refresh page after x minutes 
 
 // DO NOT MODIFY
 var isAlreadyRunning = false;

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -292,7 +292,7 @@ function toggleAutoRefresh(event) {
     if(value) {
         autoRefreshPage(autoRefreshSeconds);
     } else {
-		autoRefreshSeconds = 0;
+		enableAutoRefresh = false;	
     }
 }
 
@@ -1094,9 +1094,7 @@ function getClickDamage(){
 }
 
 function autoRefreshPage(autoRefreshSeconds){
-	if(autoRefreshSeconds > 0) {
-		setTimeout("location.reload(true);",(autoRefreshSeconds*1000));
-	}
+	setTimeout("location.reload(true);",(autoRefreshSeconds*1000));
 }
 
 function enhanceTooltips(){

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1094,7 +1094,12 @@ function getClickDamage(){
 }
 
 function autoRefreshPage(autoRefreshSeconds){
-	setTimeout("location.reload(true);",(autoRefreshSeconds*1000));
+	if(enableAutoRefresh) {
+		setTimeout("location.reload(true);",(autoRefreshSeconds*1000));
+	}
+	else {
+		console.log("auto-refresh has been disabled, so no refresh);
+	}
 }
 
 function enhanceTooltips(){

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -26,8 +26,12 @@ var removeParticles = getPreferenceBoolean("removeParticles", true);
 var removeFlinching = getPreferenceBoolean("removeFlinching", true);
 var removeCritText = getPreferenceBoolean("removeCritText", false);
 var removeAllText = getPreferenceBoolean("removeAllText", false);
-var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", false); // auto-refresh the page to clear out stale memory from leak
 
+if (GM_info !== "undefined") {
+	var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", true); // auto-refresh for GM/TM users
+} else {
+	var enableAutoRefresh = getPreferenceBoolean("enableAutoRefresh", false); // no auto-refresh for non-GM/TM users
+}
 var enableElementLock = getPreferenceBoolean("enableElementLock", true);
 
 var autoRefreshSeconds = 1800; // refresh page after x seconds


### PR DESCRIPTION
Added an option to auto-refresh the page every x seconds.

Auto-refresh defaults to 'off'. If the user is using TM or GM (queried by GM_info), then the script displays the checkbox. If GM_info doesn't return a value (user is not using GM, and is pasting in code) then it hides the checkbox and it stays disabled. 
