### PR TITLE
Fix for #77

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1090,7 +1090,7 @@ function autoRefreshPage(autoRefreshMinutes) {
 
 function fixActiveCapacityUI() {
     $J('.tv_ui').css('background-image', 'url("' + GITHUB_BASE_URL + 'game_frame_tv_fix.png")');
-    $J('#activeinlanecontainer').css('height', '134px');
+    $J('#activeinlanecontainer').css('height', '154px');
     $J('#activitycontainer').css('height', '270px');
     $J('#activityscroll').css('height', '270px');
 }


### PR DESCRIPTION
Original height of #activeinlanecontainer is 68px, 1 ability icon has a height of 42px and we're expanding the box to fit 3 lines of icons.

68 - 42 + 42*3 = 154

Looks like a simple typo.
