### PR TITLE
Renderer-disable persist through reload fix

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -220,7 +220,10 @@ if (node && node.parentNode) {
 
     if (enableRenderer) {
         toggleRenderer();
-    }
+    } 
+	if (!enableRenderer) {
+		w.g_Minigame.Renderer.render = function() {}
+	}
 
     if (w.CSceneGame !== undefined) {
         w.CSceneGame.prototype.DoScreenShake = function() {};


### PR DESCRIPTION
the 'no-render' checkbox was not persisting through page reload. This fix checks if the box is unchecked as well if it is checked in firstRun to fix that.
