### PR TITLE
Fixed gold rain lane targeting #56

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -655,30 +655,36 @@ function goToLaneWithBestTarget() {
         }
 
         //Prefer lane with raining gold, unless current enemy target is a treasure or boss.
-    if (!targetIsTreasure && !targetIsBoss){
-            var potential = 0;
+		if (!targetIsTreasure && !targetIsBoss) {
+			var potential = 0;
             // Loop through lanes by elemental preference
             var sortedLanes = sortLanesByElementals();
-            for(var notI = 0; notI < sortedLanes.length; notI++){
+            for (var notI = 0; notI < sortedLanes.length; notI++) {
                 // Maximize compability with upstream
                 i = sortedLanes[notI];
                 // ignore if lane is empty
-                if(s().m_rgGameData.lanes[i].dps === 0)
+                if (s().m_rgGameData.lanes[i].dps === 0)
                     continue;
                 var stacks = 0;
-                if(typeof s().m_rgLaneData[i].abilities[17] != 'undefined') {
+                if (typeof s().m_rgLaneData[i].abilities[17] != 'undefined') {
                     stacks = s().m_rgLaneData[i].abilities[17];
-                    advLog('stacks: ' + stacks, 3);
-                }
-                for(var m = 0; m < s().m_rgEnemies.length; m++) {
-                    var enemyGold = s().m_rgEnemies[m].m_data.gold;
-                    if (stacks * enemyGold > potential) {
-                        potential = stacks * enemyGold;
-                        preferredTarget = s().m_rgEnemies[m].m_nID;
-                        preferredLane = i;
-                    }
-                }
-            }
+                    advLog('[Gold rain] stacks: ' + stacks, 5);
+                
+					for(var m = 0; m < s().m_rgEnemies.length; m++) {
+						if(s().m_rgEnemies[m].m_nLane != i)
+							continue;
+						advLog("[Gold rain] An enemy exists in raining gold lane: " + (i + 1), 5);
+						var enemyGold = s().m_rgEnemies[m].m_data.gold;
+						if (stacks * enemyGold > potential) {
+							potential = stacks * enemyGold;
+							preferredTarget = s().m_rgEnemies[m].m_nID;
+							preferredLane = i;
+						}
+					}
+					advLog("[Gold rain] preferredLane: " + preferredLane, 5);
+					advLog("[Gold rain] preferredTarget: " +  preferredTarget, 5);
+				}
+			}	
         }
 
         // target the enemy of the specified type with the lowest hp


### PR DESCRIPTION
Do not consider an enemy for a gold rain target unless it is in the gold rain lane. Moved the for loop block of code into the if block of whether a gold rain ability is active.

Thanks to @armetilou @BuddhaBuddy1 https://github.com/wchill/steamSummerMinigame/issues/56#issuecomment-111974727
