### PR TITLE
Wormhole actually autoused and usable in lower level rooms.

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -996,7 +996,7 @@ function goToLaneWithBestTarget() {
 		} else {
 			BOSS_DISABLED_ABILITIES.forEach(enableAbility);
 		}
-		if (level < control.allowWormholeLevel) {
+		if (level < control.allowWormholeLevel && !isNearEndGame()) {
 			disableAbility(ABILITIES.WORMHOLE);
 		} else {
 			enableAbility(ABILITIES.WORMHOLE);
@@ -1271,7 +1271,7 @@ function useWormholeIfRelevant() {
 		return;
 	}
 	// Check if Wormhole is purchased
-	if (tryUsingItem(ABILITIES.WORMHOLE, true)) {
+	if (tryUsingItem(ABILITIES.WORMHOLE)) {
 		advLog('Less than ' + control.minsLeft + ' minutes for game to end. Triggering wormholes...', 2);
 	} else if (tryUsingItem(ABILITIES.THROW_MONEY_AT_SCREEN)) {
 		advLog('Less than ' + control.minsLeft + ' minutes for game to end. Throwing money at screen for no particular reason...', 2);


### PR DESCRIPTION
Fixed wormhole not being auto-used/enabled for lower level rooms and to stack during endgame. Resolves https://github.com/wchill/steamSummerMinigame/issues/185

(I'm helping, I think)

Thanks to supirman for noticing it.
