### PR TITLE
Fix autoclicker silently re-enabling on refresh if it was disabled

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -43,7 +43,7 @@
 	// DO NOT MODIFY
 	var isAlreadyRunning = false;
 	var refreshTimer = null;
-	var currentClickRate = clickRate;
+	var currentClickRate = enableAutoClicker ? clickRate : 0;
 	var lockedElement = -1;
 	var lastLevel = 0;
 	var trt_oldCrit = function() {};


### PR DESCRIPTION
Otherwise, it would have to be toggled on and off to get currentClickRate back to 0.
