### PR TITLE
Remove redundant check.

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1129,11 +1129,6 @@
 		var enemySpawnerExists = false;
 		var level = getGameLevel();
 
-		// Prevent this outright if its within control.rainingSafeRounds of the next rainingRound
-		if (level % control.rainingRounds > control.rainingRounds - control.rainingSafeRounds) {
-			return;
-		}
-
 		//Count each slot in lane
 		for (var i = 0; i < 4; i++) {
 			var enemy = s().GetEnemy(currentLane, i);

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1392,7 +1392,7 @@
 	function canUseOffensiveAbility() {
 		var level = getGameLevel();
 		var levelmod = level % control.rainingRounds;
-		// Early in the game, or we're a safe distance away from raining rounds.
+		// Whether we're a safe distance away from raining rounds.
 		return (levelmod > 0 && levelmod < control.rainingRounds - control.rainingSafeRounds);
 	}
 


### PR DESCRIPTION
For some reason #237 was closed.

Again, this check is covered on line 1122 by !canUseOffensiveAbility().

I created canUseOffensiveAbility specifically for this.
