### PR TITLE
Fix levels skipped status

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -779,7 +779,6 @@
 	function getLevelsSkipped() {
 		var total = 0;
 		for (var i = 3; i >= 0; i--) {
-			levelsSkipped[i+1] = levelsSkipped[i];
 			total += levelsSkipped[i];
 		}
 		total += levelsSkipped[0];

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -781,7 +781,6 @@
 		for (var i = 3; i >= 0; i--) {
 			total += levelsSkipped[i];
 		}
-		total += levelsSkipped[0];
 		return total;
 	}
 


### PR DESCRIPTION
Tested locally, makes the "Skipped xxx levels in last 5s" status not be about 2x what it should be.
