### PR TITLE
Fix for skipped levels being doubled

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -410,11 +410,12 @@
 			updatePlayersInGame();
 
 			if (level !== lastLevel) {
-				updateLevelInfoTitle(level, lastLevel);
-				lastLevel = level;
 				refreshPlayerData();
 			}
-
+			
+			updateLevelInfoTitle(level, lastLevel);
+			lastLevel = level;
+			
 			currentClickRate = getWantedClicksPerSecond();
 			s().m_nClicks = currentClickRate;
 			s().m_nLastTick = false;

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -410,8 +410,8 @@
 			updatePlayersInGame();
 
 			if (level !== lastLevel) {
+				updateLevelInfoTitle(level, lastLevel);
 				lastLevel = level;
-				updateLevelInfoTitle(level);
 				refreshPlayerData();
 			}
 
@@ -479,18 +479,6 @@
 						}
 					}
 				}
-			}
-
-			// Make sure to only include ticks that are relevant
-			var level_jump = getGameLevel() - oldLevel;
-			if (level_jump > 0) {
-				// Iterate down the levelskipped memory
-				for (var i = 4; i >= 0; i--) {
-					levelsSkipped[i+1] = levelsSkipped[i];
-				}
-				levelsSkipped[0] = level_jump;
-
-				oldLevel = getGameLevel();
 			}
 		}
 
@@ -776,12 +764,13 @@
 		return clickRate;
 	}
 
-	function getLevelsSkipped() {
+	function getLevelsSkipped(level, lastLevel) {
 		var total = 0;
 		for (var i = 3; i >= 0; i--) {
 			levelsSkipped[i+1] = levelsSkipped[i];
 			total += levelsSkipped[i];
 		}
+		levelsSkipped[0] = level - lastLevel;
 		total += levelsSkipped[0];
 		return total;
 	}
@@ -1619,7 +1608,7 @@
 	{
 		var exp_lvl = expectedLevel(level);
 		var rem_time = countdown(exp_lvl.remaining_time);
-		var lvl_skip = getLevelsSkipped();
+		var lvl_skip = getLevelsSkipped(level, lastLevel);
 
 		document.ExpectedLevel.textContent = 'Level: ' + level + ', Expected Level: ' + exp_lvl.expected_level + ', Likely Level: ' + exp_lvl.likely_level;
 		document.RemainingTime.textContent = 'Remaining Time: ' + rem_time.hours + ' hours, ' + rem_time.minutes + ' minutes.';

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1604,7 +1604,7 @@
 		document.LevelsSkip = element;
 	}
 
-	function updateLevelInfoTitle(level)
+	function updateLevelInfoTitle(level, lastLevel)
 	{
 		var exp_lvl = expectedLevel(level);
 		var rem_time = countdown(exp_lvl.remaining_time);


### PR DESCRIPTION
Fixes #253 
Also included are a few changes to avoid recalculating values.  Thanks to JohnMatt3000 for working through this with me.
