### PR TITLE
Disregard client cooldown when using wormholes

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1287,17 +1287,11 @@
 	}
 
 	function useWormholeIfRelevant() {
-		// Check the time before using wormhole.
 		var level = getGameLevel();
 		if (level % control.rainingRounds !== 0) {
 			return;
 		}
-		// Check if Wormhole is purchased
-		if (tryUsingItem(ABILITIES.WORMHOLE)) {
-			advLog('Less than ' + control.minsLeft + ' minutes for game to end. Triggering wormholes...', 2);
-		} else if (isNearEndGame() && tryUsingItem(ABILITIES.THROW_MONEY_AT_SCREEN)) {
-			advLog('Less than ' + control.minsLeft + ' minutes for game to end. Throwing money at screen for no particular reason...', 2);
-		}
+		triggerAbility(ABILITIES.WORMHOLE)
 	}
 
 	function useLikeNewIfRelevant() {


### PR DESCRIPTION
This will make you not wait for the server to tell your client that someone has used a "like new" before using another wormhole.

Addresses #254.
