### PR TITLE
Clean up multibuy a bit & add an autobuy button to the badge item welcome panel

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1925,7 +1925,7 @@
 					var item = items[itemName];
 					item.btn = w.$J('#purchase_abilityitem_'+item.id);
 					item.cost = parseInt(item.btn.find('span.cost').text());
-					
+
 					if(item.btn.length !== 1 || isNaN(item.cost) || item.cost === 0)
 					{
 						alert("Available items not recognised, aborting autobuy.");

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1794,9 +1794,9 @@
 	function enableMultibuy(){
 
 		var trt_oldbuy = w.g_Minigame.m_CurrentScene.TrySpendBadgePoints;
-		w.g_Minigame.m_CurrentScene.TrySpendBadgePoints = function(ele, count){
+		w.g_Minigame.m_CurrentScene.TrySpendBadgePoints = function(ele, count, skipMulti){
 
-			if (count != 1){
+			if (skipMulti || count != 1){
 				trt_oldbuy.call(w.g_Minigame.m_CurrentScene, ele, count);
 				return;
 			}

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1897,8 +1897,8 @@
 				}
 			});
 		};
-		
-		var autobuyBtn = $J('<div>Autobuy</div>');
+
+		var autobuyBtn = w.$J('<div>Autobuy</div>');
 		autobuyBtn.css('margin-top', '10px');
 		autobuyBtn.css('text-align', 'center');
 		autobuyBtn.css('padding', '5px');
@@ -1908,7 +1908,7 @@
 		autobuyBtn.css('cursor', 'pointer');
 		autobuyBtn.click(function() {
 			var numPoints = w.g_Minigame.CurrentScene().m_rgPlayerTechTree.badge_points;
-	
+
 			var items =
 			{
 				wh: {id: 26},
@@ -1916,15 +1916,15 @@
 				rain: {id: 17},
 				treasure: {id: 22},
 				pump: {id: 19}
-			}
-		
+			};
+
 			for(var itemName in items)
 			{
 				if(items.hasOwnProperty(itemName))
 				{
 					var item = items[itemName];
 					item.btn = w.$J('#purchase_abilityitem_'+item.id);
-					item.cost = parseInt(item.btn.find('span.cost').text())
+					item.cost = parseInt(item.btn.find('span.cost').text());
 					
 					if(item.btn.length !== 1 || isNaN(item.cost) || item.cost === 0)
 					{
@@ -1933,20 +1933,20 @@
 					}
 				}
 			}
-			
+
 			if(items.pump.cost === 1 && numPoints % 2 === 1)
 			{
 				w.g_Minigame.CurrentScene().TrySpendBadgePoints(items.pump.btn, 1, true);
 				numPoints -= items.pump.cost;
 			}
-		
+
 			var numLikeNew = Math.floor(numPoints / ((10*items.wh.cost)+items.likeNew.cost));
 			if(numLikeNew > 0)
 			{
 				w.g_Minigame.CurrentScene().TrySpendBadgePoints(items.likeNew.btn, numLikeNew, true);
 				numPoints -= numLikeNew*items.likeNew.cost;
 			}
-		
+
 			function buyItem(item)
 			{
 				var numItem = Math.floor(numPoints / item.cost);
@@ -1956,13 +1956,13 @@
 					numPoints -= numItem * item.cost;
 				}
 			}
-		
+
 			buyItem(items.wh);
 			buyItem(items.rain);
 			buyItem(items.treasure);
 		});
-			
-		$J('#badge_items').after(autobuyBtn);
+
+		w.$J('#badge_items').after(autobuyBtn);
 	}, false);
 
 

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1897,6 +1897,72 @@
 				}
 			});
 		};
+		
+		var autobuyBtn = $J('<div>Autobuy</div>');
+		autobuyBtn.css('margin-top', '10px');
+		autobuyBtn.css('text-align', 'center');
+		autobuyBtn.css('padding', '5px');
+		autobuyBtn.css('color', '#fff');
+		autobuyBtn.css('background-color', '#ff7b00');
+		autobuyBtn.css('display', 'block');
+		autobuyBtn.css('cursor', 'pointer');
+		autobuyBtn.click(function() {
+			var numPoints = w.g_Minigame.CurrentScene().m_rgPlayerTechTree.badge_points;
+	
+			var items =
+			{
+				wh: {id: 26},
+				likeNew: {id: 27},
+				rain: {id: 17},
+				treasure: {id: 22},
+				pump: {id: 19}
+			}
+		
+			for(var itemName in items)
+			{
+				if(items.hasOwnProperty(itemName))
+				{
+					var item = items[itemName];
+					item.btn = w.$J('#purchase_abilityitem_'+item.id);
+					item.cost = parseInt(item.btn.find('span.cost').text())
+					
+					if(item.btn.length !== 1 || isNaN(item.cost) || item.cost === 0)
+					{
+						alert("Available items not recognised, aborting autobuy.");
+						return;
+					}
+				}
+			}
+			
+			if(items.pump.cost === 1 && numPoints % 2 === 1)
+			{
+				w.g_Minigame.CurrentScene().TrySpendBadgePoints(items.pump.btn, 1, true);
+				numPoints -= items.pump.cost;
+			}
+		
+			var numLikeNew = Math.floor(numPoints / ((10*items.wh.cost)+items.likeNew.cost));
+			if(numLikeNew > 0)
+			{
+				w.g_Minigame.CurrentScene().TrySpendBadgePoints(items.likeNew.btn, numLikeNew, true);
+				numPoints -= numLikeNew*items.likeNew.cost;
+			}
+		
+			function buyItem(item)
+			{
+				var numItem = Math.floor(numPoints / item.cost);
+				if(numItem > 0)
+				{
+					w.g_Minigame.CurrentScene().TrySpendBadgePoints(item.btn, numItem, true);
+					numPoints -= numItem * item.cost;
+				}
+			}
+		
+			buyItem(items.wh);
+			buyItem(items.rain);
+			buyItem(items.treasure);
+		});
+			
+		$J('#badge_items').after(autobuyBtn);
 	}, false);
 
 

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1793,12 +1793,11 @@
 
 	function enableMultibuy(){
 
-		// We have to add this to the scene so that we can access the "this" identifier.
-		s().trt_oldbuy = w.g_Minigame.m_CurrentScene.TrySpendBadgePoints;
+		var trt_oldbuy = w.g_Minigame.m_CurrentScene.TrySpendBadgePoints;
 		w.g_Minigame.m_CurrentScene.TrySpendBadgePoints = function(ele, count){
 
 			if (count != 1){
-				s().trt_oldbuy(ele, count);
+				trt_oldbuy.call(w.g_Minigame.m_CurrentScene, ele, count);
 				return;
 			}
 
@@ -1830,7 +1829,7 @@
 				return;
 			}
 
-			s().trt_oldbuy(ele, newCount);
+			trt_oldbuy.call(w.g_Minigame.m_CurrentScene, ele, newCount);
 		};
 	}
 


### PR DESCRIPTION
With multibuy, there's no need to add the old TrySpendBadgePoints function back onto the scene object to be able to access 'this', you just have to call it with trt_oldbuy.call instead, which seems cleaner.

Also added a third parameter to the replacement of TrySpendBadgePoints which will skip the multibuy popup logic. Without that, any purchase of a single item from the autobuy script will cause a popup as if the user clicked the item themselves.

With that in place, added an autobuy button which will buy 1 Like New for every 10 Wormholes, then Raining Gold, then Treasure, and one Pumped Up if there's a point left over. It does this efficiently without looping until there are no points left. Instead, it just buys each item in a single batch. It also works off of the prices given on the welcome panel instead of hard-coded values (just in case they change or something).
