### PR TITLE
Boost wormholes usage to one/second by ignoring cooldowns.

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1347,7 +1347,9 @@
 			return;
 		}
 		// Check if Wormhole is purchased
-		if (tryUsingItem(ABILITIES.WORMHOLE)) {
+		if (hasItem(ABILITIES.WORMHOLE)) {
+			// Force usage of it regardless of cooldown. Will work if at least one NL was used suring the last second.
+			triggerAbility(ABILITIES.WORMHOLE);
 			advLog('Less than ' + control.minsLeft + ' minutes for game to end. Triggering wormholes...', 2);
 		} else if (isNearEndGame() && tryUsingItem(ABILITIES.THROW_MONEY_AT_SCREEN)) {
 			advLog('Less than ' + control.minsLeft + ' minutes for game to end. Throwing money at screen for no particular reason...', 2);

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1351,8 +1351,6 @@
 			// Force usage of it regardless of cooldown. Will work if at least one NL was used suring the last second.
 			triggerAbility(ABILITIES.WORMHOLE);
 			advLog('Less than ' + control.minsLeft + ' minutes for game to end. Triggering wormholes...', 2);
-		} else if (isNearEndGame() && tryUsingItem(ABILITIES.THROW_MONEY_AT_SCREEN)) {
-			advLog('Less than ' + control.minsLeft + ' minutes for game to end. Throwing money at screen for no particular reason...', 2);
 		}
 	}
 


### PR DESCRIPTION
You can use wormhole each tick if a NL was applied during the last second, which is always the case in WHs rooms. You don't have to wait for the cooldown to be updated.
