### PR TITLE
Reduces overrun for nukes and naplam

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1190,7 +1190,7 @@
 		var level = getGameLevel();
 
 		// Prevent this outright if its within control.rainingSafeRounds of the next rainingRound
-		if (level % control.rainingRounds > control.rainingRounds - control.rainingSafeRounds+20) {
+		if (level % control.rainingRounds > control.rainingRounds - ( control.rainingSafeRounds + 20 )) {
 			return;
 		}
 

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -548,9 +548,9 @@
 									w.$J('.name', ele).text( rgEntry.actor_name );
 									w.$J('.ability', ele).text( this.m_Game.m_rgTuningData.abilities[ rgEntry.ability ].name + " on level " + getGameLevel());
 									w.$J('img', ele).attr( 'src', w.g_rgIconMap['ability_' + rgEntry.ability].icon );
-	
+
 									w.$J(ele).v_tooltip({tooltipClass: 'ta_tooltip', location: 'top'});
-	
+
 									this.m_eleUpdateLogContainer[0].insertBefore(ele[0], this.m_eleUpdateLogContainer[0].firstChild);
 									advLog(rgEntry.actor_name + " used " + this.m_Game.m_rgTuningData.abilities[ rgEntry.ability ].name + " on level " + getGameLevel(), 1);
 									w.$J('.name', ele).attr( "style", "color: red; font-weight: bold;" );
@@ -560,9 +560,9 @@
 									w.$J('.ability', ele).text( this.m_Game.m_rgTuningData.abilities[ rgEntry.ability ].name + " on level " + getGameLevel());
 									w.$J('img', ele).attr( 'src', w.g_rgIconMap['ability_' + rgEntry.ability].icon );
 									w.$J('.name', ele).attr( "style", "color: yellow" );
-	
+
 									w.$J(ele).v_tooltip({tooltipClass: 'ta_tooltip', location: 'top'});
-	
+
 									this.m_eleUpdateLogContainer[0].insertBefore(ele[0], this.m_eleUpdateLogContainer[0].firstChild);
 								}
 							} else {
@@ -1190,7 +1190,7 @@
 		var level = getGameLevel();
 
 		// Prevent this outright if its within control.rainingSafeRounds of the next rainingRound
-		if (level % control.rainingRounds > control.rainingRounds - ( control.rainingSafeRounds + 20 )) {
+		if (level % control.rainingRounds > control.rainingRounds - ( control.rainingSafeRounds + 20 ) ) {
 			return;
 		}
 

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -35,6 +35,7 @@
 	var disableRenderer = getPreferenceBoolean("disableRenderer", false);
 	var useTrollTracker = getPreferenceBoolean("useTrollTracker", false);
 	var praiseGoldHelm = getPreferenceBoolean("praiseGoldHelm", true);
+	var disableNukes = getPreferenceBoolean("disableNukes", false);
 
 	var autoRefreshMinutes = 30; // refresh page after x minutes
 	var autoRefreshMinutesRandomDelay = 10;
@@ -238,6 +239,9 @@
 		if (disableRenderer) {
 			toggleRenderer();
 		}
+		if (disableNukes) {
+			toggleNukes();
+		}
 
 		if (w.CSceneGame !== undefined) {
 			w.CSceneGame.prototype.DoScreenShake = function() {};
@@ -302,6 +306,7 @@
 		options1.appendChild(makeCheckBox("removeGoldText", "Remove gold text", removeGoldText, handleEvent, false));
 		options1.appendChild(makeCheckBox("removeAllText", "Remove all text", removeAllText, toggleAllText, false));
 		options1.appendChild(makeCheckBox("disableRenderer", "Throttle game renderer", disableRenderer, toggleRenderer, true));
+		options1.appendChild(makeCheckBox("disableNukes", "Disable Nukes and Napalm", disableNukes, toggleNukes, false));
 
 		if (typeof GM_info !== "undefined") {
 			options1.appendChild(makeCheckBox("enableAutoRefresh", "Enable auto-refresh", enableAutoRefresh, toggleAutoRefresh, false));
@@ -808,6 +813,12 @@
 		}
 	}
 
+	function toggleNukes(event) {
+		if (event !== undefined) {
+			disableNukes = handleCheckBox(event);
+		}
+	}
+
 	function toggleCritText(event) {
 		var value = removeCritText;
 		if (event !== undefined) {
@@ -1099,6 +1110,11 @@
 				enableAbility(ABILITIES.WORMHOLE);
 			}
 		}
+		//hides nuke button
+		if ( disableNukes ){
+			disableAbility(ABILITIES.TACTICAL_NUKE);
+			disableAbility(ABILITIES.NAPALM);
+		}
 	}
 
 	function useCooldownIfRelevant() {
@@ -1179,7 +1195,7 @@
 
 	function useNapalmIfRelevant() {
 		//Check if Napalm is purchased and cooled down
-		if (!canUseAbility(ABILITIES.NAPALM) || !canUseOffensiveAbility() || Math.random() > control.useAbilityChance) {
+		if (!canUseAbility(ABILITIES.NAPALM) || !canUseOffensiveAbility() || Math.random() > control.useAbilityChance || disableNukes) {
 			return;
 		}
 
@@ -1233,7 +1249,7 @@
 
 	function useTacticalNukeIfRelevant() {
 		// Check if Tactical Nuke is purchased
-		if (!canUseAbility(ABILITIES.TACTICAL_NUKE) || !canUseOffensiveAbility() || Math.random() > control.useAbilityChance) {
+		if (!canUseAbility(ABILITIES.TACTICAL_NUKE) || !canUseOffensiveAbility() || Math.random() > control.useAbilityChance || disableNukes) {
 			return;
 		}
 

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -61,7 +61,7 @@
 	var control = {
 		speedThreshold: 2000,
 		// Stop using offensive abilities shortly before rain/wormhole rounds.
-		rainingSafeRounds: 5,
+		rainingSafeRounds: 9,
 		rainingRounds: 100,
 		timePerUpdate: 60000,
 		useSlowMode: false,
@@ -1190,7 +1190,7 @@
 		var level = getGameLevel();
 
 		// Prevent this outright if its within control.rainingSafeRounds of the next rainingRound
-		if (level % control.rainingRounds > control.rainingRounds - control.rainingSafeRounds) {
+		if (level % control.rainingRounds > control.rainingRounds - control.rainingSafeRounds+20) {
 			return;
 		}
 

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -62,7 +62,7 @@
 	var control = {
 		speedThreshold: 2000,
 		// Stop using offensive abilities shortly before rain/wormhole rounds.
-		rainingSafeRounds: 9,
+		rainingSafeRounds: 5,
 		rainingRounds: 100,
 		timePerUpdate: 60000,
 		useSlowMode: false,
@@ -1477,7 +1477,7 @@
 		var level = getGameLevel();
 		var levelmod = level % control.rainingRounds;
 		// Early in the game, or we're a safe distance away from raining rounds.
-		return (levelmod > 0 && levelmod < control.rainingRounds - control.rainingSafeRounds);
+		return (levelmod > 0 && levelmod < control.rainingRounds - ( control.rainingSafeRounds + 4 ));
 	}
 
 	function tryUsingAbility(abilityId) {


### PR DESCRIPTION
I've noticed alot of nukes and napalm running over into Gold Helm rounds so i've increased the safe rounds to 9 and the napalm to 29 to try to stop this.

reason 9 and 29 is we still want to use these on pre Gold Helm bosses
