### PR TITLE
Disable WH and nuke Buttons to aviod trigger happy users

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1114,7 +1114,7 @@
 				BOSS_DISABLED_ABILITIES.forEach(disableAbility);
 			} else {
 				BOSS_DISABLED_ABILITIES.forEach(enableAbility);
-				
+
 				//keep offence abilities disabled to avoid trigger happy players
 				disableAbility(ABILITIES.TACTICAL_NUKE);
 				disableAbility(ABILITIES.NAPALM);

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1384,8 +1384,8 @@
 			if(wormholeInterval) {
 				w.clearInterval(wormholeInterval);
 				wormholeInterval = false;
-				disableAbility(ABILITIES.WORMHOLE);
 			}
+			disableAbility(ABILITIES.WORMHOLE);
 			return;
 		}
 		if (!wormholeInterval) {

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1122,9 +1122,7 @@
 				disableAbility(ABILITIES.CRIPPLE_MONSTER);
 				disableAbility(ABILITIES.CLUSTER_BOMB);
 			}
-
 		}
-		
 	}
 
 	function useCooldownIfRelevant() {

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1115,12 +1115,14 @@
 			} else {
 				BOSS_DISABLED_ABILITIES.forEach(enableAbility);
 			}
-			if (level < control.allowWormholeLevel && !isNearEndGame()) {
-				//disableAbility(ABILITIES.WORMHOLE);
-			} else {
-				enableAbility(ABILITIES.WORMHOLE);
-			}
+
 		}
+		//keep offence abilities disabled to avoid trigger happy players
+		disableAbility(ABILITIES.TACTICAL_NUKE);
+		disableAbility(ABILITIES.NAPALM);
+		disableAbility(ABILITIES.CLUSTER_BOMB);
+		disableAbility(ABILITIES.CRIPPLE_MONSTER);
+		disableAbility(ABILITIES.CLUSTER_BOMB);
 	}
 
 	function useCooldownIfRelevant() {
@@ -1382,10 +1384,12 @@
 			if(wormholeInterval) {
 				w.clearInterval(wormholeInterval);
 				wormholeInterval = false;
+				disableAbility(ABILITIES.WORMHOLE);
 			}
 			return;
 		}
 		if (!wormholeInterval) {
+			enableAbility(ABILITIES.WORMHOLE);
 			wormholeInterval = w.setInterval(function(){
 				w.g_Minigame.m_CurrentScene.m_rgAbilityQueue.push({'ability': 26}); //wormhole
 				w.g_Minigame.m_CurrentScene.m_nLastTick = 0;

--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1114,15 +1114,17 @@
 				BOSS_DISABLED_ABILITIES.forEach(disableAbility);
 			} else {
 				BOSS_DISABLED_ABILITIES.forEach(enableAbility);
+				
+				//keep offence abilities disabled to avoid trigger happy players
+				disableAbility(ABILITIES.TACTICAL_NUKE);
+				disableAbility(ABILITIES.NAPALM);
+				disableAbility(ABILITIES.CLUSTER_BOMB);
+				disableAbility(ABILITIES.CRIPPLE_MONSTER);
+				disableAbility(ABILITIES.CLUSTER_BOMB);
 			}
 
 		}
-		//keep offence abilities disabled to avoid trigger happy players
-		disableAbility(ABILITIES.TACTICAL_NUKE);
-		disableAbility(ABILITIES.NAPALM);
-		disableAbility(ABILITIES.CLUSTER_BOMB);
-		disableAbility(ABILITIES.CRIPPLE_MONSTER);
-		disableAbility(ABILITIES.CLUSTER_BOMB);
+		
 	}
 
 	function useCooldownIfRelevant() {


### PR DESCRIPTION
Disable WH when not allowed to use such as pre level 100 or after the spam phase

disable offence skill buttons all the time since they are no longer used by script at all.

Probably not the best place in the code for these but seemed the quickest without modifying the boss disable abilities array.
