### PR TITLE
Fixed Bugs with Badge Points Which were Breaking Auto Upgrades

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -354,23 +354,31 @@
 		var badgePoints = w.g_Minigame.CurrentScene().m_rgPlayerTechTree.badge_points;
 
 		// Determine how many other things to buy
-		var buy_count = (w.g_steamID % 10) + 1;
+		var buy_count = Math.min((w.g_steamID % 10) + 1, Math.floor(badgePoints / 200));
 
 		// Buy some
-		w.g_Minigame.CurrentScene().TrySpendBadgePoints( w.$J("<a data-type='25' data-cost='200'></a>"), buy_count );
+		if (buy_count > 0) {
+			w.g_Minigame.CurrentScene().TrySpendBadgePoints( w.$J("<a data-type='25' data-cost='200'></a>"), buy_count );
+		}
 		badgePoints -= buy_count*200;
 
 		// How many WH/LN do we buy too?
 		var purchaseCount = Math.floor(badgePoints / 200);
 
 		// Buy mostly WH
-		w.g_Minigame.CurrentScene().TrySpendBadgePoints( w.$J("<a data-type='26' data-cost='100'></a>"), purchaseCount );
+		if (purchaseCount > 0) {
+			w.g_Minigame.CurrentScene().TrySpendBadgePoints( w.$J("<a data-type='26' data-cost='100'></a>"), purchaseCount );
+		}
 
 		// Buy a few LN
-		w.g_Minigame.CurrentScene().TrySpendBadgePoints( w.$J("<a data-type='27' data-cost='100'></a>"), purchaseCount );
+		if (purchaseCount > 0) {
+			w.g_Minigame.CurrentScene().TrySpendBadgePoints( w.$J("<a data-type='27' data-cost='100'></a>"), purchaseCount );
+		}
 
 		//Rest is Pumped Up
-		w.g_Minigame.CurrentScene().TrySpendBadgePoints(w.$J("<a data-type='19' data-cost='1'></a>"), badgePoints % 100 );
+		if ((badgePoints % 100) > 0) {
+			w.g_Minigame.CurrentScene().TrySpendBadgePoints(w.$J("<a data-type='19' data-cost='1'></a>"), badgePoints % 100 );
+		}
 	}
 
 	function updateLaneData() {


### PR DESCRIPTION
Calling TrySpendBadgePoints() with a count <= 0 will get past its error checking and set m_bUpgradesBusy to true, but since no items get added to m_rgPurchaseItemsQueue SendSpendBadgePointsRequest()'s error checking prevents it from attempting to make a purchase resulting in m_bUpgradesBusy remaining true.
